### PR TITLE
fix: prevent form submission on stepper buttons

### DIFF
--- a/src/components/number-input-string.ts
+++ b/src/components/number-input-string.ts
@@ -135,6 +135,7 @@ export const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>(
 
         <div className="flex flex-col">
           <Button
+            type="button"
             aria-label="Increase value"
             className="px-2 h-5 rounded-l-none rounded-br-none border-input border-l-0 border-b-[0.5px] focus-visible:relative"
             variant="outline"
@@ -144,6 +145,7 @@ export const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>(
             <ChevronUp size={15} />
           </Button>
           <Button
+            type="button"
             aria-label="Decrease value"
             className="px-2 h-5 rounded-l-none rounded-tr-none border-input border-l-0 border-t-[0.5px] focus-visible:relative"
             variant="outline"

--- a/src/components/number-input.tsx
+++ b/src/components/number-input.tsx
@@ -138,6 +138,7 @@ export const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>(
 
         <div className="flex flex-col">
           <Button
+            type="button"
             aria-label="Increase value"
             className="px-2 h-5 rounded-l-none rounded-br-none border-input border-l-0 border-b-[0.5px] focus-visible:relative"
             variant="outline"
@@ -147,6 +148,7 @@ export const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>(
             <ChevronUp size={15} />
           </Button>
           <Button
+            type="button"
             aria-label="Decrease value"
             className="px-2 h-5 rounded-l-none rounded-tr-none border-input border-l-0 border-t-[0.5px] focus-visible:relative"
             variant="outline"


### PR DESCRIPTION
Add type="button" to increment/decrement buttons to prevent unintended form submissions when clicking stepper controls.